### PR TITLE
Fixed tour.md image URLs

### DIFF
--- a/tour.md
+++ b/tour.md
@@ -3,7 +3,7 @@
 
 ## DevShop Homepage
 
-![OpenDevShop Homepage: Projects List](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/devshop-projects.png "A screenshot of the OpenDevShop Homeage: a clear list of all of your projects and all of your environments.")
+![OpenDevShop Homepage: Projects List](https://raw.githubusercontent.com/opendevshop/documentation/master/images/devshop-projects.png "A screenshot of the OpenDevShop Homeage: a clear list of all of your projects and all of your environments.")
 
 The OpenDevShop Homepage shows you a birds eye view of all your projects.  The name, install profile, git URL, Drupal Version, and a list of all the environments are visible at a glance.
 
@@ -11,7 +11,7 @@ Each environment indicator is updated in realtime. You can see the status of the
 
 ## DevShop Project Dashboard
 
-![OpenDevShop Project Dashboard](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/devshop.png "A screenshot of the OpenDevShop Project Dashboard")
+![OpenDevShop Project Dashboard](https://raw.githubusercontent.com/opendevshop/documentation/master/images/devshop.png "A screenshot of the OpenDevShop Project Dashboard")
 
 The project dashboard shows you all the information you need about your website.  Git URL, list of branches and tags,
 links to GitHub, links to the live environment, Drush aliases, and most importantly: your project's environments.
@@ -21,7 +21,7 @@ current git branch or tag, the URLs that are available, the last commit time, a 
 
 ## Environments Dashboard 
 
-![OpenDevShop Environment](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/environment-settings.png "A screenshot of an OpenDevShop Environment UI.")
+![OpenDevShop Environment](https://raw.githubusercontent.com/opendevshop/documentation/master/images/environment-settings.png "A screenshot of an OpenDevShop Environment UI.")
 
 Under the "Environment Settings" button is a list of possible tasks:
 
@@ -35,7 +35,7 @@ Under the "Environment Settings" button is a list of possible tasks:
   
 ## Deploy
 
-![Environment Code Deploy](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/deploy-code.png "A screenshot of the Deploy Code widget.")
+![Environment Code Deploy](https://raw.githubusercontent.com/opendevshop/documentation/master/images/deploy-code.png "A screenshot of the Deploy Code widget.")
 
  - The **Deploy Code** control allow you to easily change what branch or tag an environment is tracking. 
  - **Deploy Data** allows you to deliver new database and files to your environment. 
@@ -43,7 +43,7 @@ Under the "Environment Settings" button is a list of possible tasks:
 
 ## Tasks
 
-![Environment Task Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/environment-task-logs.png "A screenshot of the Environment Task Logs.")
+![Environment Task Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/images/environment-task-logs.png "A screenshot of the Environment Task Logs.")
 
 At the bottom of each environment block is a status indicator for the last task that was run on the environment.
 
@@ -55,8 +55,8 @@ DevShop is designed for developers. We want to give them exactly the information
 
 Out of this came the design of our task logs. We strive to make DevShop's activities as clear and transparent as possible.
 
-![Deploy Code Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/logs-deploy-pull.png "A screenshot of Deploy Code logs.")
+![Deploy Code Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/images/logs-deploy-pull.png "A screenshot of Deploy Code logs.")
 
-![Deploy Hooks Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/docs/images/logs-deploy-pull.png "A screenshot of Deploy Code logs running drush updb.")
+![Deploy Hooks Logs](https://raw.githubusercontent.com/opendevshop/documentation/master/images/logs-deploy-pull.png "A screenshot of Deploy Code logs running drush updb.")
 
 After the code is deployed with git, any number of *Deploy Hooks* can be run.


### PR DESCRIPTION
There was an extra directory of /docs/ that no longer exists.

See [tommycox:tour.md](https://github.com/tommycox/documentation/blob/patch-1/tour.md) for fixed images.
